### PR TITLE
Fixed: Original kapt is deprecated. Please add "apply plugin: 'kotlin…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply from: 'maven-push.gradle'
 
 android {
@@ -8,7 +9,7 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 27
-        versionCode 2
+        versionCode 3
         versionName "1.1.8"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
…-kapt'" to your build.gradle

Increased versionCode to 3.